### PR TITLE
Fixing posting controller redirection test error

### DIFF
--- a/src/main/java/com/personal/projectforum/config/SecurityConfig.java
+++ b/src/main/java/com/personal/projectforum/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
-                .httpBasic(withDefaults())
+                //.httpBasic(withDefaults())
                 .formLogin(Customizer.withDefaults())
                 .logout(Customizer.withDefaults())
                 .logout(logout -> logout.logoutSuccessUrl("/"));

--- a/src/main/java/com/personal/projectforum/controller/PostingController.java
+++ b/src/main/java/com/personal/projectforum/controller/PostingController.java
@@ -55,6 +55,7 @@ public class PostingController {
         map.addAttribute("posting",posting);
         map.addAttribute("postingComments", posting.postingCommentsResponse());
         map.addAttribute("totalCount", postingService.getPostingCount());
+        map.addAttribute("searchTypeHashtag", SearchType.HASHTAG);
         return "postings/detail";
     }
 

--- a/src/test/java/com/personal/projectforum/controller/PostingControllerTest.java
+++ b/src/test/java/com/personal/projectforum/controller/PostingControllerTest.java
@@ -137,7 +137,6 @@ class PostingControllerTest {
     @DisplayName("[view][GET] Posting Detail Page - No authentication, redirect to login page")
     @Test
     void givenNothing_whenRequestingPostingPage_thenRedirectsToLoginPage() throws Exception {
-        //TODO: Test is not passing yet
         // Given
         long postingId = 1L;
 
@@ -271,7 +270,6 @@ class PostingControllerTest {
     @DisplayName("[view][GET] Update posting page - No authentication redirect to login page")
     @Test
     void givenNothing_whenRequesting_thenRedirectsToLoginPage() throws Exception {
-        //TODO: Test is not passing yet
         // Given
         long postingId = 1L;
 


### PR DESCRIPTION
The reason was because of the 'httpBasic(withDefaults()) : With HTTP Basic Authentication, an unauthenticated request to a protected resource typically results in a 401 Unauthorized response status code. Therefore, you can expect a 401 status code without specifying a redirection URL.