### PR TITLE
 [Advancement] Refactoring of the entity code - changing the field access method from equals() & hashcode() to getter method

### DIFF
--- a/src/main/java/com/personal/projectforum/domain/Posting.java
+++ b/src/main/java/com/personal/projectforum/domain/Posting.java
@@ -51,12 +51,12 @@ public class Posting extends AuditingFields{
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof  Posting posting)) return false;
-        return id !=null && id.equals(posting.id);
+        if (!(o instanceof  Posting that)) return false;
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/personal/projectforum/domain/PostingComment.java
+++ b/src/main/java/com/personal/projectforum/domain/PostingComment.java
@@ -41,11 +41,11 @@ public class PostingComment extends AuditingFields{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof PostingComment that)) return false;
-        return id != null && id.equals(that.id);
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/personal/projectforum/domain/UserAccount.java
+++ b/src/main/java/com/personal/projectforum/domain/UserAccount.java
@@ -45,12 +45,12 @@ public class UserAccount extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof UserAccount userAccount)) return false;
-        return userId != null && userId.equals(userAccount.userId);
+        if (!(o instanceof UserAccount that)) return false;
+        return this.getUserId() != null && this.getUserId().equals(that.getUserId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 }


### PR DESCRIPTION
This pr changes the entity's equals() and hashcode() direct access to the field to getter access to compare values.
By taking into account Hibernate's lazy loading using proxy objects, we ensure that value comparisons are not performed incorrectly.