### PR TITLE
[Refactoring] Modify the wrong expression part of AuditingFields

### DIFF
--- a/src/main/java/com/personal/projectforum/domain/AuditingFields.java
+++ b/src/main/java/com/personal/projectforum/domain/AuditingFields.java
@@ -21,18 +21,18 @@ public abstract class AuditingFields {
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @CreatedDate
     @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+    protected LocalDateTime createdAt;
 
     @CreatedBy
     @Column(nullable = false, updatable = false, length = 100)
-    private String createdBy;
+    protected String createdBy;
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @LastModifiedDate
     @Column(nullable = false)
-    private LocalDateTime modifiedAt;
+    protected LocalDateTime modifiedAt;
 
     @LastModifiedBy
     @Column(nullable = false, length = 100)
-    private String modifiedBy;
+    protected String modifiedBy;
 }


### PR DESCRIPTION
This pr modifies the field access modifier of AuditingFields to protected for the abstract class.
This will be necessary when information needs to be recorded without authentication.
A representative example is membership registration.

This closes #91 